### PR TITLE
Fix vuln policy table occasionally getting stuck in loading

### DIFF
--- a/src/views/policy/PolicyManagement.vue
+++ b/src/views/policy/PolicyManagement.vue
@@ -9,7 +9,7 @@
         <template v-slot:title><i class="fa fa-balance-scale"></i> {{ $t('message.license_groups') }} <b-badge variant="tab-total">{{ totalLicenseGroups }}</b-badge></template>
         <license-group-list v-on:total="totalLicenseGroups = $event" />
       </b-tab>
-      <b-tab ref="vulnerabilitypolicies" class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " @click="routeTo('vulnerability')">
+      <b-tab ref="vulnerability" class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " @click="routeTo('vulnerability')">
         <template v-slot:title><i class="fa fa-list-alt"></i> {{ $t('message.vulnerability_policies') }} <b-badge variant="tab-total">{{ totalVulnerabilityPolicies }}</b-badge></template>
         <vulnerability-policy-list v-on:total="totalVulnerabilityPolicies = $event" />
       </b-tab>
@@ -54,11 +54,17 @@
       }
     },
     mounted() {
-      this.getTabFromRoute().active = true;
+      const tab = this.getTabFromRoute();
+      if (tab) {
+        tab.active = true;
+      }
     },
     watch: {
       $route() {
-        this.getTabFromRoute().activate();
+        const tab = this.getTabFromRoute();
+        if (tab) {
+          tab.activate();
+        }
       }
     }
   }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

The logic that is supposed to activate tabs based on the route (`this.getTabFromRoute()`) did not check the return value. This lead to fields / methods being called on an `undefined` object, which caused further loading of the page to crash. The vulnerability policy table was stuck in loading mode, even though the API returned a proper response.

Also fixed the vulnerability policy tab losing focus when reloading the page.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
